### PR TITLE
Downgrade transformers to 4.45 to match NxDI release 2.21

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -5,7 +5,7 @@ requests >= 2.26.0
 tqdm
 blake3
 py-cpuinfo
-transformers >= 4.48.2  # Required for Bamba model and Transformers backend.
+transformers >= 4.45.0  # Required by NxDI release 2.21.
 tokenizers >= 0.19.1  # Required for Llama 3.
 protobuf # Required by LlamaTokenizer.
 fastapi >= 0.107.0, < 0.113.0; python_version < '3.9'


### PR DESCRIPTION
Downgrade transformers to 4.45 to match NxDI release 2.21.

For release 2.22 onwards, we will switch back to 4.48.
