### PR TITLE
Add multi-lora support

### DIFF
--- a/examples/offline_inference/neuron_multi_lora.py
+++ b/examples/offline_inference/neuron_multi_lora.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import traceback
+
+from vllm import LLM, SamplingParams
+from vllm.entrypoints.openai.serving_models import LoRAModulePath
+from vllm.lora.request import LoRARequest
+
+LORA_CKPT_PATH = "~/models/llama-3.1-8b-lora-adapter"
+# Use neuronx-distributed-inference framework over transformers-neuronx
+os.environ['VLLM_NEURON_FRAMEWORK'] = "neuronx-distributed-inference"
+os.environ['NEURON_RT_DBG_RDH_CC'] = '0'
+os.environ['NEURON_RT_INSPECT_ENABLE'] = '0'
+os.environ['XLA_HANDLE_SPECIAL_SCALAR'] = '1'
+os.environ['UNSAFE_FP8FNCAST'] = '1'
+
+
+def run_vllm(prompts, model_name_or_path, n_positions, max_batch_size,
+             tp_degree):
+    sampling_params = SamplingParams(top_k=1)
+    override_neuron_config = {
+        "sequence_parallel_enabled": False,
+    }
+    llm = LLM(model=model_name_or_path,
+              tensor_parallel_size=tp_degree,
+              max_num_seqs=max_batch_size,
+              max_model_len=n_positions,
+              use_v2_block_manager=True,
+              override_neuron_config=override_neuron_config,
+              lora_modules=[
+                  LoRAModulePath(name="lora_id_1", path=LORA_CKPT_PATH),
+                  LoRAModulePath(name="lora_id_2", path=LORA_CKPT_PATH)
+              ],
+              enable_lora=True,
+              max_loras=2,
+              max_lora_rank=256,
+              device="neuron")
+    """For multi-lora requests using NxDI as the backend, only the lora_name 
+    needs to be specified. The lora_id and lora_path are supplied at the LLM 
+    class/server initialization, after which the paths are handled by NxDI"""
+    lora_req_1 = LoRARequest("lora_id_1", 0, " ")
+    lora_req_2 = LoRARequest("lora_id_2", 1, " ")
+    # outputs = llm.generate(prompts, sampling_params)
+    outputs = llm.generate(prompts,
+                           sampling_params,
+                           lora_request=[lora_req_1, lora_req_2])
+    for output in outputs:
+        prompt = output.prompt
+        generated_text = output.outputs[0].text
+        print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
+
+    return [output.prompt + output.outputs[0].text for output in outputs]
+
+
+def vllm_integ_test(model,
+                    n_positions,
+                    max_batch_size,
+                    tp_degree,
+                    model_name_or_path=None):
+    if model_name_or_path is None:
+        raise ValueError(
+            "Please provide either 's3_model_dir' or 'model_name_or_path' in "
+            "the test definition")
+
+    # Sample prompts.
+    prompts = [
+        "The president of the United States is",
+        "The capital of France is",
+    ]
+    vllm_outputs = run_vllm(prompts, model_name_or_path, n_positions,
+                            max_batch_size, tp_degree)
+
+    # check if actual outputs is the prefix of expected output
+    # we cannot compare the full sequence as each actual outputs has different
+    # length due to continuous batching
+    for actual_seq in vllm_outputs:
+        print(f"actual: {actual_seq}")
+
+
+def run_vllm_integration_test(param, **kwargs):
+    model = param["model"]
+    model_path = param["model_path"]
+
+    results = {}
+    try:
+        vllm_integ_test(
+            model,
+            param["max_context_length"] + param["max_new_tokens"],
+            param["batch_size"],
+            param["tp_degree"],
+            model_name_or_path=model_path,
+        )
+        results["inference_success"] = True
+    except Exception:
+        print(traceback.format_exc())
+        results["inference_success"] = False
+
+    return results
+
+
+def main():
+    param = {
+        "max_context_length": 256,
+        "max_new_tokens": 256,
+        "batch_size": 4,
+        "tp_degree": 32,
+        "model_path": "/home/ubuntu/models/llama-3.1-8b",
+        "model": "llama-3.1-8b",
+    }
+    run_vllm_integration_test(param)
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/model_executor/model_loader/neuronx_distributed.py
+++ b/vllm/model_executor/model_loader/neuronx_distributed.py
@@ -17,6 +17,8 @@ from neuronx_distributed_inference.models.config import (
     FusedSpecNeuronConfig, OnDeviceSamplingConfig)
 from neuronx_distributed_inference.models.mllama.utils import (
     create_vision_mask)
+from neuronx_distributed_inference.modules.lora_serving import (
+    LoraServingConfig)
 from neuronx_distributed_inference.utils.hf_adapter import (
     load_pretrained_config)
 from transformers import AutoModelForCausalLM, AutoTokenizer, PretrainedConfig
@@ -77,13 +79,13 @@ class NeuronCausalLM(nn.Module):
         # Lazy initialized
         self.model: nn.Module
 
-    def forward(
-        self,
-        input_ids: torch.Tensor,
-        positions: torch.Tensor,
-        input_block_ids: torch.Tensor,
-        sampling_params: torch.Tensor,
-    ) -> torch.Tensor:
+    def forward(self,
+                input_ids: torch.Tensor,
+                positions: torch.Tensor,
+                input_block_ids: torch.Tensor,
+                sampling_params: torch.Tensor,
+                prev_hidden: Optional[torch.Tensor] = None,
+                adapter_ids: Optional[torch.Tensor] = None) -> torch.Tensor:
         # sort block ids sequentially for perf/neuron support reasons
         sorted_input_block_ids, sorted_indices = torch.sort(input_block_ids)
         input_ids = torch.index_select(input_ids, 0, sorted_indices)
@@ -95,7 +97,9 @@ class NeuronCausalLM(nn.Module):
                             attention_mask=None,
                             position_ids=positions,
                             seq_ids=sorted_input_block_ids,
-                            sampling_params=sampling_params)
+                            sampling_params=sampling_params,
+                            prev_hidden=prev_hidden,
+                            adapter_ids=adapter_ids)
         # on-device sampling
         if self.config.neuron_config.on_device_sampling_config:
             output = output.hidden_states
@@ -519,7 +523,8 @@ def _get_model_architecture(config: PretrainedConfig) -> str:
 
 def _get_default_neuron_config(model_config: ModelConfig,
                                parallel_config: ParallelConfig,
-                               scheduler_config: SchedulerConfig):
+                               scheduler_config: SchedulerConfig,
+                               lora_serving_config: LoraServingConfig):
     """Generate a neuron config based on vllm config args."""
     on_device_sampling_config = OnDeviceSamplingConfig(dynamic=True,
                                                        deterministic=False)
@@ -538,7 +543,7 @@ def _get_default_neuron_config(model_config: ModelConfig,
         padding_side="right",
         on_device_sampling_config=on_device_sampling_config,
         sequence_parallel_enabled=True,
-    )
+        lora_config=lora_serving_config)
     return neuron_config
 
 
@@ -576,7 +581,8 @@ def _get_neuron_config_after_override(default_neuron_config,
 
 def get_neuron_model(model_config: ModelConfig,
                      parallel_config: ParallelConfig,
-                     scheduler_config: SchedulerConfig) -> nn.Module:
+                     scheduler_config: SchedulerConfig,
+                     lora_serving_config: LoraServingConfig) -> nn.Module:
     """Initializes a neuron-optimized model for inference."""
     model_arch = _get_model_architecture(model_config.hf_config)
     if model_arch == "MllamaForConditionalGeneration":
@@ -584,7 +590,7 @@ def get_neuron_model(model_config: ModelConfig,
     else:
         model = NeuronCausalLM(model_config.hf_config)
     default_neuron_config_args = _get_default_neuron_config(
-        model_config, parallel_config, scheduler_config)
+        model_config, parallel_config, scheduler_config, lora_serving_config)
     neuron_config = _get_neuron_config_after_override(
         default_neuron_config_args, model_config.override_neuron_config)
 

--- a/vllm/platforms/neuron.py
+++ b/vllm/platforms/neuron.py
@@ -41,9 +41,6 @@ class NeuronPlatform(Platform):
         if parallel_config.world_size > 1:
             parallel_config.distributed_executor_backend = "uni"
 
-        assert (vllm_config.lora_config
-                is None), "LoRA is not supported for Neuron backend."
-
         cache_config = vllm_config.cache_config
         if cache_config:
             # neuron needs block_size = max_model_len

--- a/vllm/worker/neuron_model_runner.py
+++ b/vllm/worker/neuron_model_runner.py
@@ -36,6 +36,7 @@ class ModelInputForNeuron(ModelRunnerInputBase):
     input_block_ids: Optional[torch.Tensor] = None
     sampling_metadata: SamplingMetadata = None
     multi_modal_kwargs: BatchedTensorInputs = None
+    adapter_ids: Optional[str] = None
 
     def as_broadcastable_tensor_dict(
             self) -> Dict[str, Union[int, torch.Tensor]]:
@@ -80,6 +81,8 @@ class NeuronModelRunner(ModelRunnerBase[ModelInputForNeuron]):
                            "The model will run without sliding window.")
         self.device_config = (self.device_config if self.device_config
                               is not None else DeviceConfig())
+
+        self.lora_config = vllm_config.lora_config
         self.device = self.device_config.device
         self.pin_memory = is_pin_memory_available()
 
@@ -388,6 +391,7 @@ class NeuronModelRunner(ModelRunnerBase[ModelInputForNeuron]):
                 positions=model_input.input_positions,
                 input_block_ids=model_input.input_block_ids,
                 sampling_params=sampling_params,
+                adapter_ids=model_input.adapter_ids,
                 **MultiModalKwargs.as_kwargs(model_input.multi_modal_kwargs
                                              or {},
                                              device=self.device),

--- a/vllm/worker/neuron_model_runner.py
+++ b/vllm/worker/neuron_model_runner.py
@@ -2,13 +2,15 @@
 
 import os
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union
 
 import torch
 from torch import nn
 
 from vllm.config import DeviceConfig, VllmConfig
 from vllm.logger import init_logger
+from vllm.lora.layers import LoRAMapping
+from vllm.lora.request import LoRARequest
 from vllm.model_executor import SamplingMetadata
 from vllm.model_executor.layers.sampler import SamplerOutput
 from vllm.model_executor.model_loader.neuron import get_neuron_model
@@ -430,3 +432,28 @@ class NeuronModelRunner(ModelRunnerBase[ModelInputForNeuron]):
     def process_multi_modal_data_neuron(self, mm_data):
         # this is a no-op for NeuronModelRunner
         return mm_data
+
+    def remove_all_loras(self):
+        raise NotImplementedError(
+            "LoRAs are not supported for Transformers NeuronX framework")
+
+    def set_active_loras(self, lora_requests: Set[LoRARequest],
+                         lora_mapping: LoRAMapping) -> None:
+        raise NotImplementedError(
+            "LoRAs are not supported for Transformers NeuronX framework")
+
+    def add_lora(self, lora_request: LoRARequest):
+        raise NotImplementedError(
+            "LoRAs are not supported for Transformers NeuronX framework")
+
+    def remove_lora(self, lora_id: int) -> bool:
+        raise NotImplementedError(
+            "LoRAs are not supported for Transformers NeuronX framework")
+
+    def pin_lora(self, lora_id: int) -> bool:
+        raise NotImplementedError(
+            "LoRAs are not supported for Transformers NeuronX framework")
+
+    def list_loras(self) -> Set[int]:
+        raise NotImplementedError(
+            "LoRAs are not supported for Transformers NeuronX framework")

--- a/vllm/worker/neuronx_distributed_model_runner.py
+++ b/vllm/worker/neuronx_distributed_model_runner.py
@@ -1,22 +1,29 @@
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List, Optional
+from typing import List, Optional, Set
 
 import torch
 from neuronx_distributed_inference.models.mllama.image_transform import (
     custom_image_preprocessing)
 from neuronx_distributed_inference.modules.generation.sampling import (
     prepare_sampling_params)
+from neuronx_distributed_inference.modules.lora_serving import (
+    LoraCheckpoint, LoraServingConfig)
 from PIL.Image import Image as PILImage
 
 from vllm.config import VllmConfig
+from vllm.entrypoints.openai.serving_models import LoRAModulePath
 from vllm.logger import init_logger
+from vllm.lora.layers import LoRAMapping
+from vllm.lora.request import LoRARequest
+from vllm.model_executor import SamplingMetadata
 from vllm.model_executor.layers.sampler import SamplerOutput
 from vllm.model_executor.model_loader.neuronx_distributed import (
     _get_model_architecture, get_neuron_model)
-from vllm.sequence import IntermediateTensors
+from vllm.sequence import IntermediateTensors, SequenceGroupMetadata
 from vllm.worker.neuron_model_runner import (ModelInputForNeuron,
                                              NeuronModelRunner)
+from vllm.worker.utils import use_transformers_neuronx
 
 logger = init_logger(__name__)
 
@@ -28,11 +35,44 @@ class NeuronxDistributedModelRunner(NeuronModelRunner):
         vllm_config: VllmConfig,
     ):
         super().__init__(vllm_config)
+        self.lora_checkpoint = None
+        self.model = None
+        self.lora_serving_config = None
+
+    @staticmethod
+    def _get_lora_paths_strings(lora_modules: List[LoRAModulePath]):
+        if not lora_modules:
+            return None
+        return {_.name: _.path for _ in lora_modules}
+
+    def _get_nxdi_lora_config(self):
+        override_neuron_config = self.model_config.override_neuron_config
+        lora_modules = override_neuron_config.pop("lora_modules", None)
+        target_modules = override_neuron_config.pop("target_modules", None)
+        lora_ckpt_paths = self._get_lora_paths_strings(lora_modules)
+        if self.lora_config.max_loras < len(lora_ckpt_paths):
+            raise ValueError(
+                "Number of LoRAs (%s) exceeds maximum "
+                "allowed (%s)", len(lora_ckpt_paths),
+                self.lora_config.max_loras)
+
+        return LoraServingConfig(
+            max_loras=self.lora_config.max_loras,
+            max_lora_rank=self.lora_config.max_lora_rank,
+            target_modules=target_modules,
+            lora_ckpt_paths=lora_ckpt_paths,
+        )
 
     def load_model(self) -> None:
-        self.model = get_neuron_model(self.model_config,
-                                      parallel_config=self.parallel_config,
-                                      scheduler_config=self.scheduler_config)
+        # Update LoRA config
+        if self.lora_config is not None:
+            self.lora_serving_config = self._get_nxdi_lora_config()
+            self.lora_checkpoint = LoraCheckpoint(self.lora_serving_config)
+        self.model = get_neuron_model(
+            self.model_config,
+            parallel_config=self.parallel_config,
+            scheduler_config=self.scheduler_config,
+            lora_serving_config=self.lora_serving_config)
 
     def get_nxd_sampling_params(self, sampling_metadata):
         if self.model.config.neuron_config.on_device_sampling_config:
@@ -162,3 +202,122 @@ class NeuronxDistributedModelRunner(NeuronModelRunner):
         mm_data["has_image"] = torch.cat(has_image_list, dim=0).squeeze(0)
 
         return mm_data
+
+    def _get_lora_adapter_ids(self, seq_group_metadata_list):
+        # set LoRA adapter IDs for multi-lora serving
+        batch_size = len(seq_group_metadata_list)
+        if self.lora_checkpoint is not None:
+            # "0" indicates NxDI to use the base model for inference
+            adapter_ids = ["0"] * batch_size
+            for idx, seq_group_metadata in enumerate(seq_group_metadata_list):
+                if seq_group_metadata.lora_request is not None:
+                    adapter_ids[
+                        idx] = seq_group_metadata.lora_request.lora_name
+
+            # convert adapter_ids from strings to integers
+            adapter_ids = self.lora_checkpoint.convert_adapter_ids_to_indices(
+                adapter_ids, batch_size)
+        else:
+            adapter_ids = torch.zeros((batch_size), dtype=torch.int32)
+
+        return adapter_ids
+
+    def prepare_model_input(
+        self,
+        seq_group_metadata_list: List[SequenceGroupMetadata],
+        virtual_engine: int = 0,
+        finished_requests_ids: Optional[List[str]] = None
+    ) -> ModelInputForNeuron:
+        multi_modal_kwargs = None
+        # NOTE: We assume that all sequences in the group are all prompts or
+        # all decodes.
+        is_prompt = seq_group_metadata_list[0].is_prompt
+        # Prepare input tensors.
+        if is_prompt:
+            (input_tokens, input_positions, input_block_ids, seq_lens,
+             multi_modal_kwargs
+             ) = self._prepare_prompt(seq_group_metadata_list)
+        else:
+            (input_tokens, input_positions,
+             input_block_ids) = self._prepare_decode(seq_group_metadata_list)
+            seq_lens = None
+
+        if not self._on_device_sampling_disabled:
+            for seq_group_metadata in seq_group_metadata_list:
+                sampling_params = seq_group_metadata.sampling_params
+                top_k, top_p, temperature = (
+                    self._convert_to_neuron_sampling_params(sampling_params))
+                sampling_params.top_k = top_k
+                sampling_params.top_p = top_p
+                sampling_params.temperature = temperature
+
+        lora_adapter_ids = self._get_lora_adapter_ids(seq_group_metadata_list)
+
+        sampling_metadata = SamplingMetadata.prepare(
+            seq_group_metadata_list,
+            seq_lens,
+            # query_lens is not needed if chunked prefill is not
+            # supported. Since neuron worker doesn't support chunked prefill
+            # just use seq_lens instead.
+            seq_lens,
+            self.device,
+            self.pin_memory,
+            generators=self.get_generators(finished_requests_ids))
+
+        if use_transformers_neuronx(
+        ) and not self._on_device_sampling_disabled:
+            # Once the request IDs are changed in current iteration, we will
+            # update the on-device sampling parameters.
+            current_batch_request_ids = [
+                seq_group_meta_data.request_id
+                for seq_group_meta_data in seq_group_metadata_list
+            ]
+            if current_batch_request_ids != self._previous_batch_request_ids:
+                self._update_neuron_sampling_params(seq_group_metadata_list)
+                self._previous_batch_request_ids = current_batch_request_ids
+
+        return ModelInputForNeuron(input_tokens=input_tokens,
+                                   input_positions=input_positions,
+                                   input_block_ids=input_block_ids,
+                                   sampling_metadata=sampling_metadata,
+                                   multi_modal_kwargs=multi_modal_kwargs,
+                                   adapter_ids=lora_adapter_ids)
+
+    def remove_all_loras(self):
+        raise NotImplementedError(
+            "Managing LoRAs is only supported through the "
+            "lora_modules parameter to the LLM Class"
+            " or --lora-modules while using online server)")
+
+    def set_active_loras(self, lora_requests: Set[LoRARequest],
+                         lora_mapping: LoRAMapping) -> None:
+        raise NotImplementedError(
+            "Managing LoRAs is only supported through the "
+            "lora_modules parameter to the LLM Class"
+            " or --lora-modules while using online server)")
+
+    def add_lora(self, lora_request: LoRARequest) -> bool:
+        logger.warning(
+            "Adding LoRAs is only supported through the "
+            "lora_modules parameter to the LLM Class"
+            " or --lora-modules while using online server. If you supplied "
+            "the parameter, you can ignore this warning. Ignoring"
+            "lora request: ", lora_request)
+
+    def remove_lora(self, lora_id: int) -> bool:
+        raise NotImplementedError(
+            "Managing LoRAs is only supported through the "
+            "lora_modules parameter to the LLM Class"
+            " or --lora-modules while using online server)")
+
+    def pin_lora(self, lora_id: int) -> bool:
+        raise NotImplementedError(
+            "Managing LoRAs is only supported through the "
+            "lora_modules parameter to the LLM Class"
+            " or --lora-modules while using online server)")
+
+    def list_loras(self) -> Set[int]:
+        raise NotImplementedError(
+            "Managing LoRAs is only supported through the "
+            "lora_modules parameter to the LLM Class"
+            " or --lora-modules while using online server)")

--- a/vllm/worker/neuronx_distributed_model_runner.py
+++ b/vllm/worker/neuronx_distributed_model_runner.py
@@ -296,7 +296,7 @@ class NeuronxDistributedModelRunner(NeuronModelRunner):
             "lora_modules parameter to the LLM Class"
             " or --lora-modules while using online server)")
 
-    def add_lora(self, lora_request: LoRARequest) -> bool:
+    def add_lora(self, lora_request: LoRARequest):
         logger.warning(
             "Adding LoRAs is only supported through the "
             "lora_modules parameter to the LLM Class"


### PR DESCRIPTION
Add multi-lora inference support with Neuron

---
# Testing
## Online server and client testing logs:
```
INFO:     Started server process [78617]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)


ubuntu@ip-10-3-166-74:~$ curl http://localhost:8000/v1/chat/completions   -H "Content-Type: application/json"   -d '{
    "model": "lora_id_1",
    "messages": [
        {
            "role": "system", 
            "content": "You are a helpful assistant. Provide direct, factual answers without HTML formatting. Stay focused on the current question."
        },
        {
            "role": "user", 
            "content": "Who won the champions league in 2015"
        }
    ] 
}'
{"id":"chat-3adbb1c4d825414080c65aff1372029c","object":"chat.completion","created":1741220481,"model":"models/llama-3.1-8b","choices":[{"index":0,"message":{"role":"assistant","content":"The 2014–15 UEFA Champions League was the 60th season of Europe's premier club football tournament organised by UEFA, and the 23rd season since it was renamed from the European Champion Clubs' Cup to the UEFA Champions League.\n\nThe final was played between Barcelona, who won their fifth title, and Juventus, who lost the final for the second time in 21 years. Barcelona defeated Juventus ","tool_calls":[]},"logprobs":null,"finish_reason":"length","stop_reason":null}],"usage":{"prompt_tokens":46,"total_tokens":128,"completion_tokens":82},"prompt_logprobs":null}
```


---


##Offline VLLM test logs:
```
INFO:Neuron:Warmup completed in 5.706415414810181 seconds.
INFO 03-06 19:34:56 executor_base.py:110] # CPU blocks: 4, # CPU blocks: 0
INFO 03-06 19:34:56 executor_base.py:115] Maximum concurrency for 512 tokens per request: 4.00x
INFO 03-06 19:34:56 llm_engine.py:435] init engine (profile, create kv cache, warmup model) took 0.00 seconds
WARNING 03-06 19:34:56 tokenizer.py:238] No tokenizer found in  , using base model tokenizer instead. (Exception: Incorrect path_or_model_id: ' '. Please provide either the path to a local folder or the repo_id of a model on the Hub.)
WARNING 03-06 19:34:56 tokenizer.py:238] No tokenizer found in  , using base model tokenizer instead. (Exception: Incorrect path_or_model_id: ' '. Please provide either the path to a local folder or the repo_id of a model on the Hub.)
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00,  6.54it/s, est. speed input: 45.76 toks/s, output: 104.60 toks/s]
Prompt: 'The president of the United States is', Generated text: ' the head of state and head of government of the United States, indirectly elected to'
Prompt: 'The capital of France is', Generated text: ' a city of many faces. It is a city of history, a city of'
```
---