### PR TITLE
Get rid of preemption logic in scheduler for neuron

### DIFF
--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -601,7 +601,8 @@ class Scheduler:
 
             # NOTE(woosuk): Preemption happens only when there is no available
             # slot to keep all the sequence groups in the RUNNING state.
-            while not self._can_append_slots(seq_group, enable_chunking):
+            while ((not current_platform.is_neuron()) or
+                   (not self._can_append_slots(seq_group, enable_chunking))):
                 budget.subtract_num_batched_tokens(seq_group.request_id,
                                                    num_running_tokens)
                 num_running_seqs = seq_group.get_max_num_running_seqs()


### PR DESCRIPTION
### Change Description

We want to get rid of the preemption logic within vllm scheduler to allow usage of the max_concurrency instead of max_concurrency-1 (behavior without this change.)

BS=1 runs without this change always calls context encoding model, even for token generation.

Without this change, Avg generation throughput was detected as a peak of 2. With this change it is back up to 120 as expected. 

### Testing
* How were your changes tested? 
  * scp the Vllm folder into a personal trn1 instance and run an integration test. Observed the avg generation throughput before and after the change. Verified that the avg generation throughput is 120 after the change and 2 before the change. 
* Did you add unit tests? If not, why?
  * Unit tests are not necessary as no new functionality is added. 

### Integration Testing
* Did you run any integration tests? If yes, post the test name and the output below. 
If no, why aren't integration tests applicable here?

Test name: `NeuronxDistributedTestConfig-2.5 / test_llama_31_8b_key_configs_perf_trn1`

Relevant snippet from test output: 
```

 30%|███       | 15/50 [03:17<07:37, 13.06s/it]INFO:     127.0.0.1:52610 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO 03-11 01:14:01 metrics.py:455] Avg prompt throughput: 1712.0 tokens/s, Avg generation throughput: 108.1 tokens/s, Running: 1 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 100.0%, CPU KV cache usage: 0.0%.
INFO 03-11 01:14:06 metrics.py:455] Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 119.4 tokens/s, Running: 1 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 100.0%, CPU KV cache usage: 0.0%.
INFO 03-11 01:14:11 metrics.py:455] Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 119.7 tokens/s, Running: 1 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 100.0%, CPU KV cache usage: 0.0%.

```

### Checklist
* Post the console output of `pre-commit run --all-files` below 

```
yapf.....................................................................Passed
ruff.....................................................................Passed
codespell................................................................Passed
isort....................................................................Passed
clang-format.............................................................Passed
PyMarkdown...............................................................Passed
Lint GitHub Actions workflow files.......................................Passed
Run mypy for local Python installation...................................Passed
Lint shell scripts.......................................................Passed
Lint PNG exports from excalidraw.........................................Passed
Check SPDX headers.......................................................Passed
Suggestion...............................................................Passed

```

* Post the output of `pre-commit run mypy-3.12 --hook-stage manual --all-files` below 

```
Run mypy for Python 3.12.................................................Passed

```