### PR TITLE
Minor bug fixes

### DIFF
--- a/vllm/model_executor/model_loader/neuronx_distributed.py
+++ b/vllm/model_executor/model_loader/neuronx_distributed.py
@@ -555,7 +555,6 @@ def _get_default_neuron_config(model_config: ModelConfig,
         torch_dtype=TORCH_DTYPE_TO_NEURON_AMP[model_config.dtype],
         padding_side="right",
         on_device_sampling_config=on_device_sampling_config,
-        sequence_parallel_enabled=True,
         lora_config=lora_serving_config)
     return neuron_config
 

--- a/vllm/model_executor/model_loader/neuronx_distributed.py
+++ b/vllm/model_executor/model_loader/neuronx_distributed.py
@@ -184,6 +184,7 @@ class NeuronCausalLM(nn.Module):
             for k, v in override_neuron_config.items():
                 setattr(self.model.config.neuron_config, k, v)
             self.model.load(compiled_model_path)
+            self.config.neuron_config = self.model.config.neuron_config
             logger.info(
                 "Successfully loaded precompiled model artifacts from %s",
                 compiled_model_path)


### PR DESCRIPTION
1. Fix a bug where the precompiled neuron_config is accidentally omitted 
2. Remove `sequence_parallel_enabled=True` flag from the default neuron_config (the default behavior is False)

<!--- pyml disable-next-line no-emphasis-as-heading -->
