### PR TITLE
Remove pre-emption logic for Neuron

### DIFF
--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -14,6 +14,7 @@ from vllm.config import CacheConfig, LoRAConfig, SchedulerConfig
 from vllm.core.interfaces import AllocStatus, BlockSpaceManager
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
+from vllm.platforms import current_platform
 from vllm.prompt_adapter.request import PromptAdapterRequest
 from vllm.sequence import (Sequence, SequenceData, SequenceGroup,
                            SequenceGroupBase, SequenceGroupMetadata,
@@ -735,7 +736,8 @@ class Scheduler:
 
             # NOTE(woosuk): Preemption happens only when there is no available
             # slot to keep all the sequence groups in the RUNNING state.
-            while not self._can_append_slots(seq_group, enable_chunking):
+            while ((not current_platform.is_neuron()) and
+                   (not self._can_append_slots(seq_group, enable_chunking))):
                 budget.subtract_num_batched_tokens(seq_group.request_id,
                                                    num_running_tokens)
                 num_running_seqs = seq_group.get_max_num_running_seqs()


### PR DESCRIPTION
Remove pre-emption logic for neuron. Originally identified by @sssrijan-amazon 

Without this change, Avg generation throughput was detected as a peak of 2. With this change it is back up to 120 as expected.
