### PR TITLE
Pin 2.26 SDK versions to avoid long installations

### DIFF
--- a/requirements/neuron.txt
+++ b/requirements/neuron.txt
@@ -4,8 +4,8 @@
 # Dependencies for Neuron devices
 packaging>=24.2
 setuptools>=77.0.3,<80.0.0
-torch-neuronx >= 2.5.0
-neuronx-cc>=2.0.0a0
+torch-neuronx==2.8.0.2.10.13553
+neuronx-cc==2.21.18209.0
 torchvision # Required for Llama3.2 multimodal image preprocessing
 h11>=0.16.0
 pillow>=11.3.0

--- a/requirements/neuron.txt
+++ b/requirements/neuron.txt
@@ -4,7 +4,7 @@
 # Dependencies for Neuron devices
 packaging>=24.2
 setuptools>=77.0.3,<80.0.0
-torch-neuronx==2.8.0.2.10.13553
+torch-neuronx>=2.7.0.2.10.13553
 neuronx-cc==2.21.18209.0
 torchvision # Required for Llama3.2 multimodal image preprocessing
 h11>=0.16.0


### PR DESCRIPTION
Please. It takes forever to install because pip downloads every version >2 of neuronx-cc. You have different branches for each SDK version anyway.


If you don't want to change it for each SDK release, at least do >=the current build as of today to cut down on the time.

You should maybe change this in the main and then update every branch.

Covered by existing test plan.

<!--- pyml disable-next-line no-emphasis-as-heading -->
