### PR TITLE
Update neuronx-cc version to match Neuron 2.26.1 SDK

### DIFF
--- a/requirements/neuron.txt
+++ b/requirements/neuron.txt
@@ -5,7 +5,7 @@
 packaging>=24.2
 setuptools>=77.0.3,<80.0.0
 torch-neuronx>=2.7.0.2.10.13553
-neuronx-cc==2.21.18209.0
+neuronx-cc>=2.21.33363.0
 torchvision # Required for Llama3.2 multimodal image preprocessing
 h11>=0.16.0
 pillow>=11.3.0


### PR DESCRIPTION
Update neuronx-cc version requirement from ==2.21.18209.0 to >=2.21.33363.0 to match Neuron 2.26.1 requirements.

### Testing

Tested with Neuron 2.26.1 DLAMi and it set the right Compiler version.

```
Requirement already satisfied: torch-neuronx>=2.7.0.2.10.13553 in /opt/aws_neuronx_venv_pytorch_2_8_nxd_inference/lib/python3.10/site-packages (from -r requirements/neuron.txt (line 7)) (2.8.0.2.10.16998+e9bf8a50)
Requirement already satisfied: neuronx-cc>=2.21.33363.0 in /opt/aws_neuronx_venv_pytorch_2_8_nxd_inference/lib/python3.10/site-packages (from -r requirements/neuron.txt (line 8)) (2.21.33363.0+82129205)
```