### PR TITLE
docs: add deprecation/experimental disclaimer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
+<!-- BEGIN AWS Neuron deprecation notice -->
+> [!WARNING]
+> ## ⚠️ Deprecated / Experimental — Not Maintained
+>
+> This repository is an **experimental fork** of [vllm-project/vllm](https://github.com/vllm-project/vllm)
+> that was used to stage AWS Neuron support for upstreaming to vLLM. **It is no longer actively
+> maintained** (last functional update: Neuron SDK 2.23, mid-2025) and is provided **as-is, for
+> reference only**.
+>
+> - **Do not use this repository in production.**
+> - It will not receive feature, compatibility, or **security** updates. Known vulnerabilities in
+>   development/test-only dependencies (for example `ray`) are **not** patched
+>   here; these packages are test-scope only and are not part of any shipped runtime artifact.
+> - For current AWS Neuron + vLLM support, please follow the actively-maintained integration
+>   documented in the [AWS Neuron SDK documentation](https://awsdocs-neuron.readthedocs-hosted.com/).
+>
+> This notice is in line with AWS guidance for experimental/unmaintained public repositories.
+<!-- END AWS Neuron deprecation notice -->
+
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vllm-project/vllm/main/docs/assets/logos/vllm-logo-text-dark.png">


### PR DESCRIPTION
This repository is an unmaintained experimental fork of vllm-project/vllm that was used to stage AWS Neuron upstreaming. Add a prominent notice that it is no longer maintained, is not intended for production use, and will not receive feature, compatibility, or security updates. Point users to the maintained AWS Neuron + vLLM integration.

## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

Adds a prominent deprecation / experimental notice to the top of the README. This repository is an unmaintained experimental fork of [vllm-project/vllm](https://github.com/vllm-project/vllm) that was used to stage AWS Neuron support for upstreaming to vLLM. It has not received functional updates since ~Neuron SDK 2.23 (mid-2025), but the README still presents as the standard upstream vLLM project, which can mislead users into adopting it for production.

The notice makes the repository's status explicit and redirects users to the maintained AWS Neuron + vLLM integration.

## Test Plan

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
